### PR TITLE
refactor: reuse shared motion presets

### DIFF
--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
+import { MotionFadeIn } from "../motions/MotionFadeIn";
 import { useMousePosition } from '../hooks/useMousePosition';
 import { Code2, Globe, Award, Users } from 'lucide-react';
 
@@ -70,40 +71,25 @@ export function About() {
             </motion.h2>
             
             <div className="space-y-6 text-gray-300 leading-relaxed">
-              <motion.p
-                initial={{ opacity: 0, y: 30 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.2 }}
-                viewport={{ once: true }}
-              >
-                I earned a <strong>Master's in Computer Design Engineering</strong> — not in software, but in systems, structure, and logic. 
-                That mindset has shaped a <strong>15-year journey</strong> across web development: from backend frameworks to CI/CD 
-                pipelines and infrastructure. I've lived and worked in <strong>Belarus, Berlin, New York</strong>, and now <strong>Los Angeles</strong> — 
+              <MotionFadeIn as="p" delay={0.2}>
+                I earned a <strong>Master's in Computer Design Engineering</strong> — not in software, but in systems, structure, and logic.
+                That mindset has shaped a <strong>15-year journey</strong> across web development: from backend frameworks to CI/CD
+                pipelines and infrastructure. I've lived and worked in <strong>Belarus, Berlin, New York</strong>, and now <strong>Los Angeles</strong> —
                 contributing across tech stacks and product stages in early-stage startups and global organizations.
-              </motion.p>
-              
-              <motion.p
-                initial={{ opacity: 0, y: 30 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.4 }}
-                viewport={{ once: true }}
-              >
-                I've grown with <strong>the web</strong> — from no-syntax editors and hand-coded HTML to modern UIs and scalable microservices; 
-                from raw SQL and on-prem development to cloud infrastructures, Docker and Kubernetes; from tightly coupled 
+              </MotionFadeIn>
+
+              <MotionFadeIn as="p" delay={0.4}>
+                I've grown with <strong>the web</strong> — from no-syntax editors and hand-coded HTML to modern UIs and scalable microservices;
+                from raw SQL and on-prem development to cloud infrastructures, Docker and Kubernetes; from tightly coupled
                 monoliths to modular, distributed systems. Each shift has refined <strong>how I build</strong> — and <strong>how I rebuild better</strong>.
-              </motion.p>
-              
-              <motion.p
-                initial={{ opacity: 0, y: 30 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.6 }}
-                viewport={{ once: true }}
-              >
-                As a <strong>Staff Frontend Engineer</strong>, I've helped to <strong>form engineering teams, shape hiring practices</strong>, and 
-                <strong>drive development strategies</strong> at scale. I've led <strong>legacy decoupling, defined architectural evolution</strong>, 
-                and <strong>established coding standards</strong> across cross-functional teams. I've worked closely with product and platform teams, 
+              </MotionFadeIn>
+
+              <MotionFadeIn as="p" delay={0.6}>
+                As a <strong>Staff Frontend Engineer</strong>, I've helped to <strong>form engineering teams, shape hiring practices</strong>, and
+                <strong>drive development strategies</strong> at scale. I've led <strong>legacy decoupling, defined architectural evolution</strong>,
+                and <strong>established coding standards</strong> across cross-functional teams. I've worked closely with product and platform teams,
                 <strong>mentored engineers</strong>, and remained <strong>a consistent contributor</strong> to the codebase — combining strategy with hands-on execution.
-              </motion.p>
+              </MotionFadeIn>
             </div>
           </motion.div>
           

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
+import { MotionFadeIn } from "../motions/MotionFadeIn";
 import { Badge } from "./ui/badge";
 import { useMousePosition } from '../hooks/useMousePosition';
 import { Code, Database, Cloud, Zap, Wrench, TestTube } from 'lucide-react';
@@ -75,16 +76,13 @@ export function Skills() {
       />
 
       <div className="max-w-6xl mx-auto relative z-10">
-        <motion.h2 
+        <MotionFadeIn
+          as="h2"
           className="text-4xl md:text-5xl font-bold text-center mb-4 text-white relative"
-          initial={{ opacity: 0, y: 50 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-          viewport={{ once: true }}
           style={{ transform: `translateY(${scrollY * -0.03}px)` }}
         >
           Tech Stack
-          
+
           {/* Animated circuit lines */}
           <motion.div
             className="absolute -top-8 left-1/2 transform -translate-x-1/2 w-32 h-1"
@@ -100,18 +98,16 @@ export function Skills() {
               delay: 0.5,
             }}
           />
-        </motion.h2>
+        </MotionFadeIn>
 
-        <motion.p
+        <MotionFadeIn
+          as="p"
           className="text-center text-gray-400 mb-16 max-w-2xl mx-auto"
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          viewport={{ once: true }}
+          delay={0.3}
         >
-          15 years of web development with deep JavaScript expertise and a frontend focus. 
+          15 years of web development with deep JavaScript expertise and a frontend focus.
           Skilled in React, Node.js, NestJS, and Next.js across monoliths, SPAs, microservices, and monorepos.
-        </motion.p>
+        </MotionFadeIn>
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {skillCategories.map((category, index) => {

--- a/src/app/motions/MotionFadeIn.tsx
+++ b/src/app/motions/MotionFadeIn.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { ReactNode, ElementType } from "react";
+import { m } from "motion/react";
+import { fadeInUp, slowSpring } from "./animationPresets";
+
+type MotionTag = keyof typeof m;
+
+type Props = {
+  as?: MotionTag;
+  className?: string;
+  children: ReactNode;
+  delay?: number;
+  once?: boolean;
+  style?: React.CSSProperties;
+};
+
+export function MotionFadeIn({ as = "div", className, children, delay = 0, once = true, style }: Props) {
+  const Component = (m as Record<MotionTag, ElementType>)[as];
+  return (
+    <Component
+      className={className}
+      style={style}
+      variants={fadeInUp}
+      initial="initial"
+      whileInView="animate"
+      viewport={{ once }}
+      transition={{ ...slowSpring, delay }}
+    >
+      {children}
+    </Component>
+  );
+}


### PR DESCRIPTION
## Summary
- add MotionFadeIn utility for common fade-in animations
- refactor About and Skills components to use MotionFadeIn

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c1b1ddfa88331a672deac4890c957