### PR TITLE
refactor: extract graph backgrounds into components

### DIFF
--- a/public/graphs/cyberpunk-hexagon.svg
+++ b/public/graphs/cyberpunk-hexagon.svg
@@ -1,0 +1,1 @@
+<svg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'><g fill='none' stroke='#00d4ff' stroke-width='0.5'><path d='M50 10 L75 30 L75 70 L50 90 L25 70 L25 30 Z'/><path d='M50 25 L65 40 L65 60 L50 75 L35 60 L35 40 Z'/><circle cx='50' cy='50' r='8'/><line x1='35' y1='35' x2='65' y2='65'/><line x1='35' y1='65' x2='65' y2='35'/></g></svg>

--- a/public/graphs/digital-matrix.svg
+++ b/public/graphs/digital-matrix.svg
@@ -1,0 +1,1 @@
+<svg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'><g fill='none' fill-rule='evenodd'><g fill='#00ff41' fill-opacity='1'><path d='M30 0v60M0 30h60'/><circle cx='30' cy='30' r='4'/><path d='M15 15h30v30H15z' stroke='#00ff41' stroke-width='0.5' fill='none'/></g></g></svg>

--- a/public/graphs/project-detail-bg.svg
+++ b/public/graphs/project-detail-bg.svg
@@ -1,0 +1,1 @@
+<svg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'><g fill='none' stroke='#00d4ff' stroke-width='0.5'><path d='M30 0v60M0 30h60'/><circle cx='30' cy='30' r='25'/><circle cx='30' cy='30' r='15'/><circle cx='30' cy='30' r='5'/></g></svg>

--- a/public/graphs/work-history-bg.svg
+++ b/public/graphs/work-history-bg.svg
@@ -1,0 +1,1 @@
+<svg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'><g fill='none' stroke='#ff006e' stroke-width='0.5'><path d='M30 0v60M0 30h60'/><circle cx='30' cy='30' r='25'/><circle cx='30' cy='30' r='15'/><circle cx='30' cy='30' r='5'/></g></svg>

--- a/src/app/components/ParallaxBackground.tsx
+++ b/src/app/components/ParallaxBackground.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { m } from 'motion/react';
 import { useMousePosition } from '../hooks/useMousePosition';
+import {
+  GraphCyberCircuit,
+  GraphDigitalMatrix,
+  GraphCyberpunkHexagon,
+} from '../graphs';
 
 export function ParallaxBackground() {
   const [scrollY, setScrollY] = useState(0);
@@ -19,38 +24,17 @@ export function ParallaxBackground() {
   return (
     <div className="fixed inset-0 pointer-events-none overflow-hidden z-0">
       {/* Cyberpunk Circuit Grid Layer */}
-      <m.div
-        className="absolute inset-0 opacity-10"
-        style={{
-          transform: `translateY(${scrollY * 0.1}px)`,
-          backgroundImage: `
-            linear-gradient(rgba(0, 212, 255, 0.3) 1px, transparent 1px),
-            linear-gradient(90deg, rgba(0, 212, 255, 0.3) 1px, transparent 1px),
-            linear-gradient(rgba(255, 0, 110, 0.2) 1px, transparent 1px),
-            linear-gradient(90deg, rgba(255, 0, 110, 0.2) 1px, transparent 1px)
-          `,
-          backgroundSize: '100px 100px, 100px 100px, 50px 50px, 50px 50px',
-        }}
-        animate={{
-          x: mouseXPercent * 0.02,
-          y: mouseYPercent * 0.02,
-        }}
-        transition={{ type: 'spring', stiffness: 150, damping: 15 }}
+      <GraphCyberCircuit
+        scrollY={scrollY}
+        mouseXPercent={mouseXPercent}
+        mouseYPercent={mouseYPercent}
       />
 
       {/* Digital Matrix Pattern */}
-      <m.div
-        className="absolute inset-0 opacity-5"
-        style={{
-          transform: `translateY(${scrollY * -0.15}px)`,
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%2300ff41' fill-opacity='1'%3E%3Cpath d='M30 0v60M0 30h60'/%3E%3Ccircle cx='30' cy='30' r='4'/%3E%3Cpath d='M15 15h30v30H15z' stroke='%2300ff41' stroke-width='0.5' fill='none'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-          backgroundSize: '120px 120px',
-        }}
-        animate={{
-          x: mouseXPercent * -0.01,
-          y: mouseYPercent * -0.01,
-        }}
-        transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+      <GraphDigitalMatrix
+        scrollY={scrollY}
+        mouseXPercent={mouseXPercent}
+        mouseYPercent={mouseYPercent}
       />
 
       {/* Floating Holographic Elements */}
@@ -127,19 +111,10 @@ export function ParallaxBackground() {
       />
 
       {/* Cyberpunk Hexagon Pattern */}
-      <m.div
-        className="absolute inset-0 opacity-5 mix-blend-screen"
-        style={{
-          transform: `translateY(${scrollY * 0.05}px)`,
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='%2300d4ff' stroke-width='0.5'%3E%3Cpath d='M50 10 L75 30 L75 70 L50 90 L25 70 L25 30 Z'/%3E%3Cpath d='M50 25 L65 40 L65 60 L50 75 L35 60 L35 40 Z'/%3E%3Ccircle cx='50' cy='50' r='8'/%3E%3Cline x1='35' y1='35' x2='65' y2='65'/%3E%3Cline x1='35' y1='65' x2='65' y2='35'/%3E%3C/g%3E%3C/svg%3E")`,
-          backgroundSize: '200px 200px',
-        }}
-        animate={{
-          x: mouseXPercent * 0.01,
-          y: mouseYPercent * 0.01,
-          rotate: scrollY * 0.01,
-        }}
-        transition={{ type: 'spring', stiffness: 200, damping: 25 }}
+      <GraphCyberpunkHexagon
+        scrollY={scrollY}
+        mouseXPercent={mouseXPercent}
+        mouseYPercent={mouseYPercent}
       />
 
       {/* Dynamic Light Rays */}

--- a/src/app/components/ProjectDetail.tsx
+++ b/src/app/components/ProjectDetail.tsx
@@ -4,6 +4,7 @@ import { MotionFadeIn } from '../motions/MotionFadeIn';
 import { ArrowLeft, ExternalLink, Github, Calendar, Users, Zap, X } from 'lucide-react';
 import { Button } from '../ui/button';
 import { useMousePosition } from '../hooks/useMousePosition';
+import { GraphProjectDetail } from '../graphs';
 
 interface Project {
   id: string;
@@ -48,18 +49,10 @@ export function ProjectDetail({ project, onBack, isModal = false }: ProjectDetai
     <div className={`relative ${isModal ? 'p-0' : 'min-h-screen py-32 px-4'} overflow-hidden`}>
       {/* Background effects - only for full page view */}
       {!isModal && (
-        <m.div
-          className="absolute inset-0 opacity-5"
-          style={{
-            transform: `translateY(${scrollY * 0.1}px)`,
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='%2300d4ff' stroke-width='0.5'%3E%3Cpath d='M30 0v60M0 30h60'/%3E%3Ccircle cx='30' cy='30' r='25'/%3E%3Ccircle cx='30' cy='30' r='15'/%3E%3Ccircle cx='30' cy='30' r='5'/%3E%3C/g%3E%3C/svg%3E")`,
-            backgroundSize: '120px 120px',
-          }}
-          animate={{
-            x: mouseXPercent * -1,
-            y: mouseYPercent * -0.5,
-          }}
-          transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+        <GraphProjectDetail
+          scrollY={scrollY}
+          mouseXPercent={mouseXPercent}
+          mouseYPercent={mouseYPercent}
         />
       )}
 

--- a/src/app/components/WorkHistory.tsx
+++ b/src/app/components/WorkHistory.tsx
@@ -6,6 +6,7 @@ import { MotionSection } from '../motions/MotionSection';
 import { MotionFadeIn } from '../motions/MotionFadeIn';
 import { MotionSlideIn } from '../motions/MotionSlideIn';
 import { useData } from '../context/DataContext';
+import { GraphWorkHistory } from '../graphs';
 
 interface WorkExperience {
   id: string;
@@ -59,18 +60,10 @@ export function WorkHistory() {
   return (
     <div id="work-history" className="relative py-32 px-4 overflow-hidden">
       {/* Background pattern */}
-      <m.div
-        className="absolute inset-0 opacity-5"
-        style={{
-          transform: `translateY(${scrollY * 0.1}px)`,
-          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='%23ff006e' stroke-width='0.5'%3E%3Cpath d='M30 0v60M0 30h60'/%3E%3Ccircle cx='30' cy='30' r='25'/%3E%3Ccircle cx='30' cy='30' r='15'/%3E%3Ccircle cx='30' cy='30' r='5'/%3E%3C/g%3E%3C/svg%3E")`,
-          backgroundSize: '120px 120px',
-        }}
-        animate={{
-          x: mouseXPercent * -2,
-          y: mouseYPercent * -1,
-        }}
-        transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+      <GraphWorkHistory
+        scrollY={scrollY}
+        mouseXPercent={mouseXPercent}
+        mouseYPercent={mouseYPercent}
       />
 
       <div className="max-w-6xl mx-auto">

--- a/src/app/graphs/GraphCyberCircuit.tsx
+++ b/src/app/graphs/GraphCyberCircuit.tsx
@@ -1,0 +1,30 @@
+import { m } from 'motion/react';
+
+interface GraphCyberCircuitProps {
+  scrollY: number;
+  mouseXPercent: number;
+  mouseYPercent: number;
+}
+
+export function GraphCyberCircuit({ scrollY, mouseXPercent, mouseYPercent }: GraphCyberCircuitProps) {
+  return (
+    <m.div
+      className="absolute inset-0 opacity-10"
+      style={{
+        transform: `translateY(${scrollY * 0.1}px)`,
+        backgroundImage: `
+            linear-gradient(rgba(0, 212, 255, 0.3) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0, 212, 255, 0.3) 1px, transparent 1px),
+            linear-gradient(rgba(255, 0, 110, 0.2) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255, 0, 110, 0.2) 1px, transparent 1px)
+          `,
+        backgroundSize: '100px 100px, 100px 100px, 50px 50px, 50px 50px',
+      }}
+      animate={{
+        x: mouseXPercent * 0.02,
+        y: mouseYPercent * 0.02,
+      }}
+      transition={{ type: 'spring', stiffness: 150, damping: 15 }}
+    />
+  );
+}

--- a/src/app/graphs/GraphCyberpunkHexagon.tsx
+++ b/src/app/graphs/GraphCyberpunkHexagon.tsx
@@ -1,0 +1,26 @@
+import { m } from 'motion/react';
+
+interface GraphCyberpunkHexagonProps {
+  scrollY: number;
+  mouseXPercent: number;
+  mouseYPercent: number;
+}
+
+export function GraphCyberpunkHexagon({ scrollY, mouseXPercent, mouseYPercent }: GraphCyberpunkHexagonProps) {
+  return (
+    <m.div
+      className="absolute inset-0 opacity-5 mix-blend-screen"
+      style={{
+        transform: `translateY(${scrollY * 0.05}px)`,
+        backgroundImage: "url('/graphs/cyberpunk-hexagon.svg')",
+        backgroundSize: '200px 200px',
+      }}
+      animate={{
+        x: mouseXPercent * 0.01,
+        y: mouseYPercent * 0.01,
+        rotate: scrollY * 0.01,
+      }}
+      transition={{ type: 'spring', stiffness: 200, damping: 25 }}
+    />
+  );
+}

--- a/src/app/graphs/GraphDigitalMatrix.tsx
+++ b/src/app/graphs/GraphDigitalMatrix.tsx
@@ -1,0 +1,25 @@
+import { m } from 'motion/react';
+
+interface GraphDigitalMatrixProps {
+  scrollY: number;
+  mouseXPercent: number;
+  mouseYPercent: number;
+}
+
+export function GraphDigitalMatrix({ scrollY, mouseXPercent, mouseYPercent }: GraphDigitalMatrixProps) {
+  return (
+    <m.div
+      className="absolute inset-0 opacity-5"
+      style={{
+        transform: `translateY(${scrollY * -0.15}px)`,
+        backgroundImage: "url('/graphs/digital-matrix.svg')",
+        backgroundSize: '120px 120px',
+      }}
+      animate={{
+        x: mouseXPercent * -0.01,
+        y: mouseYPercent * -0.01,
+      }}
+      transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+    />
+  );
+}

--- a/src/app/graphs/GraphProjectDetail.tsx
+++ b/src/app/graphs/GraphProjectDetail.tsx
@@ -1,0 +1,25 @@
+import { m } from 'motion/react';
+
+interface GraphProjectDetailProps {
+  scrollY: number;
+  mouseXPercent: number;
+  mouseYPercent: number;
+}
+
+export function GraphProjectDetail({ scrollY, mouseXPercent, mouseYPercent }: GraphProjectDetailProps) {
+  return (
+    <m.div
+      className="absolute inset-0 opacity-5"
+      style={{
+        transform: `translateY(${scrollY * 0.1}px)`,
+        backgroundImage: "url('/graphs/project-detail-bg.svg')",
+        backgroundSize: '120px 120px',
+      }}
+      animate={{
+        x: mouseXPercent * -1,
+        y: mouseYPercent * -0.5,
+      }}
+      transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+    />
+  );
+}

--- a/src/app/graphs/GraphWorkHistory.tsx
+++ b/src/app/graphs/GraphWorkHistory.tsx
@@ -1,0 +1,25 @@
+import { m } from 'motion/react';
+
+interface GraphWorkHistoryProps {
+  scrollY: number;
+  mouseXPercent: number;
+  mouseYPercent: number;
+}
+
+export function GraphWorkHistory({ scrollY, mouseXPercent, mouseYPercent }: GraphWorkHistoryProps) {
+  return (
+    <m.div
+      className="absolute inset-0 opacity-5"
+      style={{
+        transform: `translateY(${scrollY * 0.1}px)`,
+        backgroundImage: "url('/graphs/work-history-bg.svg')",
+        backgroundSize: '120px 120px',
+      }}
+      animate={{
+        x: mouseXPercent * -2,
+        y: mouseYPercent * -1,
+      }}
+      transition={{ type: 'spring', stiffness: 100, damping: 20 }}
+    />
+  );
+}

--- a/src/app/graphs/index.ts
+++ b/src/app/graphs/index.ts
@@ -1,0 +1,5 @@
+export { GraphCyberCircuit } from './GraphCyberCircuit';
+export { GraphDigitalMatrix } from './GraphDigitalMatrix';
+export { GraphCyberpunkHexagon } from './GraphCyberpunkHexagon';
+export { GraphProjectDetail } from './GraphProjectDetail';
+export { GraphWorkHistory } from './GraphWorkHistory';

--- a/src/app/motions/MotionFadeIn.tsx
+++ b/src/app/motions/MotionFadeIn.tsx
@@ -20,13 +20,12 @@ export function MotionFadeIn({ as = "div", className, children, delay = 0, once 
   return (
     <Component
       className={className}
-      style={{ ...style, willChange: "opacity, transform" }}
+      style={{ willChange: "opacity, transform", ...style }}
       variants={fadeInUp}
       initial="initial"
       whileInView="animate"
       viewport={{ once }}
       transition={{ ...slowSpring, duration: 0.6, delay }}
-      style={{ willChange: "opacity, transform", ...style }}
     >
       {children}
     </Component>


### PR DESCRIPTION
## Summary
- extract parallax and section background patterns into `Graph*` components under `src/app/graphs`
- update ParallaxBackground, ProjectDetail, and WorkHistory to render new graph components
- fix duplicate style prop in MotionFadeIn

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Can't resolve 'tailwind-merge')*

------
https://chatgpt.com/codex/tasks/task_e_689d309d32548331be7235f816e4d9be