### PR TITLE
refactor: leverage motion hooks for scroll and pointer data

### DIFF
--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
 import { m } from 'motion/react';
 import { MotionFadeIn } from "../motions/MotionFadeIn";
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import { Code2, Globe, Award, Users } from 'lucide-react';
 
 const highlights = [
@@ -12,14 +12,8 @@ const highlights = [
 ];
 
 export function About() {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const mousePosition = useMousePosition();
-
-  useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 2;
   const mouseYPercent = (mousePosition.y / window.innerHeight - 0.5) * 2;

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -4,10 +4,11 @@ import { MotionFadeIn } from '../motions/MotionFadeIn';
 import { Button } from "../ui/button";
 import { ArrowDown, Github, Linkedin, Mail, Terminal } from "lucide-react";
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import { useData } from '../context/DataContext';
 
 export function Hero() {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const [textIndex, setTextIndex] = useState(0);
   const mousePosition = useMousePosition();
   const { intro } = useData();
@@ -21,17 +22,11 @@ export function Hero() {
   ];
 
   useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
-
-  useEffect(() => {
     const interval = setInterval(() => {
       setTextIndex((prev) => (prev + 1) % rotatingTitles.length);
     }, 3000);
     return () => clearInterval(interval);
-  }, []);
+  }, [rotatingTitles.length]);
 
   // Calculate mouse movement effects
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 2;

--- a/src/app/components/ParallaxBackground.tsx
+++ b/src/app/components/ParallaxBackground.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
 import { m } from 'motion/react';
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import {
   GraphCyberCircuit,
   GraphDigitalMatrix,
@@ -8,14 +8,8 @@ import {
 } from '../graphs';
 
 export function ParallaxBackground() {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const mousePosition = useMousePosition();
-
-  useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   // Calculate mouse movement effects
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 100;

--- a/src/app/components/ProjectDetail.tsx
+++ b/src/app/components/ProjectDetail.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
 import { m } from 'motion/react';
 import { MotionFadeIn } from '../motions/MotionFadeIn';
 import { ArrowLeft, ExternalLink, Github, Calendar, Users, Zap, X } from 'lucide-react';
 import { Button } from '../ui/button';
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import { GraphProjectDetail } from '../graphs';
 
 interface Project {
@@ -31,16 +31,8 @@ interface ProjectDetailProps {
 }
 
 export function ProjectDetail({ project, onBack, isModal = false }: ProjectDetailProps) {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const mousePosition = useMousePosition();
-
-  useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    if (!isModal) {
-      window.addEventListener('scroll', handleScroll);
-      return () => window.removeEventListener('scroll', handleScroll);
-    }
-  }, [isModal]);
 
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 2;
   const mouseYPercent = (mousePosition.y / window.innerHeight - 0.5) * 2;

--- a/src/app/components/Qualification.tsx
+++ b/src/app/components/Qualification.tsx
@@ -1,21 +1,15 @@
-import { useState, useEffect } from 'react';
 import { m } from 'motion/react';
 import { MotionFadeIn } from "../motions/MotionFadeIn";
 import { Badge } from "../ui/badge";
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import { Code, Database, Cloud, Zap, Wrench, TestTube } from 'lucide-react';
 import { useData } from '../context/DataContext';
 
 export function Qualification() {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const mousePosition = useMousePosition();
   const { skills } = useData();
-
-  useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 2;
   const mouseYPercent = (mousePosition.y / window.innerHeight - 0.5) * 2;

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -1,21 +1,15 @@
-import { useState, useEffect } from 'react';
 import { m } from 'motion/react';
 import { MotionFadeIn } from "../motions/MotionFadeIn";
 import { Badge } from "../ui/badge";
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import { Code, Database, Cloud, Zap, Wrench, TestTube } from 'lucide-react';
 import { useData } from '../context/DataContext';
 
 export function Skills() {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const mousePosition = useMousePosition();
   const { skills } = useData();
-
-  useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 2;
   const mouseYPercent = (mousePosition.y / window.innerHeight - 0.5) * 2;

--- a/src/app/components/WorkHistory.tsx
+++ b/src/app/components/WorkHistory.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { m } from 'motion/react';
 import { Calendar, MapPin, Users, TrendingUp, ExternalLink, Building } from 'lucide-react';
 import { useMousePosition } from '../hooks/useMousePosition';
+import { useScrollPosition } from '../hooks/useScrollPosition';
 import { MotionSection } from '../motions/MotionSection';
 import { MotionFadeIn } from '../motions/MotionFadeIn';
 import { MotionSlideIn } from '../motions/MotionSlideIn';
@@ -24,15 +25,9 @@ interface WorkExperience {
 }
 
 export function WorkHistory() {
-  const [scrollY, setScrollY] = useState(0);
+  const scrollY = useScrollPosition();
   const [expandedId, setExpandedId] = useState<string>('');
   const mousePosition = useMousePosition();
-
-  useEffect(() => {
-    const handleScroll = () => setScrollY(window.scrollY);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const mouseXPercent = (mousePosition.x / window.innerWidth - 0.5) * 2;
   const mouseYPercent = (mousePosition.y / window.innerHeight - 0.5) * 2;

--- a/src/app/hooks/useMotionValues.tsx
+++ b/src/app/hooks/useMotionValues.tsx
@@ -1,23 +1,24 @@
 "use client";
-import { useEffect } from "react";
-import { motionValue, useSpring } from "motion/react";
+import { useRef } from "react";
+import {
+  useMotionValue,
+  useSpring,
+  useScroll,
+  useVelocity,
+  useMotionValueEvent,
+  useDomEvent,
+} from "motion/react";
 
+// Track mouse position using Motion's utilities
 export function useMouseMV() {
-  const x = motionValue(0);
-  const y = motionValue(0);
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
 
-  useEffect(() => {
-    let r = 0;
-    const onMove = (e: MouseEvent) => {
-      cancelAnimationFrame(r);
-      r = requestAnimationFrame(() => {
-        x.set(e.clientX);
-        y.set(e.clientY);
-      });
-    };
-    window.addEventListener("mousemove", onMove, { passive: true });
-    return () => window.removeEventListener("mousemove", onMove);
-  }, [x, y]);
+  // Attach mousemove listener via Motion's useDomEvent
+  useDomEvent(window, "mousemove", (e: MouseEvent) => {
+    x.set(e.clientX);
+    y.set(e.clientY);
+  });
 
   const xs = useSpring(x, { stiffness: 400, damping: 40 });
   const ys = useSpring(y, { stiffness: 400, damping: 40 });
@@ -25,31 +26,22 @@ export function useMouseMV() {
   return { x: xs, y: ys };
 }
 
+// Track scroll position, velocity and direction with Motion hooks
 export function useScrollMV() {
-  const y = motionValue(0);
-  const vy = motionValue(0);
-  const dir = motionValue<"up" | "down">("down");
+  const { scrollY } = useScroll();
+  const velocity = useVelocity(scrollY);
+  const dir = useMotionValue<"up" | "down">("down");
+  const lastY = useRef(0);
 
-  useEffect(() => {
-    let last = window.scrollY;
-    let raf = 0;
-    const onScroll = () => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(() => {
-        const curr = window.scrollY;
-        const v = curr - last;
-        y.set(curr);
-        vy.set(Math.abs(v));
-        dir.set(v >= 0 ? "down" : "up");
-        last = curr;
-      });
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, [y, vy, dir]);
+  // Determine scroll direction whenever scrollY changes
+  useMotionValueEvent(scrollY, "change", (latest) => {
+    dir.set(latest - lastY.current >= 0 ? "down" : "up");
+    lastY.current = latest;
+  });
 
-  const ys = useSpring(y, { stiffness: 200, damping: 30, mass: 0.8 });
-  const vys = useSpring(vy, { stiffness: 300, damping: 40, mass: 0.6 });
+  const ys = useSpring(scrollY, { stiffness: 200, damping: 30, mass: 0.8 });
+  const vys = useSpring(velocity, { stiffness: 300, damping: 40, mass: 0.6 });
 
   return { y: ys, vy: vys, dir };
 }
+

--- a/src/app/hooks/useScrollPosition.tsx
+++ b/src/app/hooks/useScrollPosition.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { useState } from "react";
+import { useScroll, useMotionValueEvent } from "motion/react";
+
+// Returns the current vertical scroll position as a number
+export function useScrollPosition() {
+  const { scrollY } = useScroll();
+  const [y, setY] = useState(0);
+  useMotionValueEvent(scrollY, "change", (latest) => setY(latest));
+  return y;
+}
+


### PR DESCRIPTION
## Summary
- replace manual scroll and mouse tracking with Motion's `useScroll`, `useVelocity`, and `useDomEvent`
- add reusable hooks for scroll position and pointer coordinates
- update UI components to consume shared hooks instead of window listeners

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d387c10508331b4ec631f2d422615