### PR TITLE
feat: add reusable animated headline and icon components

### DIFF
--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -1,5 +1,7 @@
 import { m } from 'motion/react';
 import { MotionFadeIn } from "../graphs/MotionFadeIn";
+import { AnimatedHeadline } from "../graphs/AnimatedHeadline";
+import { AnimatedIcon } from "../graphs/AnimatedIcon";
 import { useMousePosition } from '../hooks/useMousePosition';
 import { useScrollPosition } from '../hooks/useScrollPosition';
 import { Code2, Globe, Award, Users } from 'lucide-react';
@@ -44,23 +46,9 @@ export function About() {
             }}
             transition={{ type: 'spring', stiffness: 150, damping: 20 }}
           >
-            <m.h2 
-              className="text-4xl md:text-5xl font-bold mb-8 text-white relative"
-              initial={{ opacity: 0, x: -50 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.8 }}
-              viewport={{ once: true }}
-            >
+            <AnimatedHeadline className="text-4xl md:text-5xl font-bold mb-8 text-white" accent>
               The Evolution
-              {/* Animated accent */}
-              <m.div
-                className="absolute -bottom-2 left-0 h-1 bg-gradient-to-r from-white via-gray-400 to-transparent"
-                initial={{ width: 0 }}
-                whileInView={{ width: '60%' }}
-                transition={{ duration: 1, delay: 0.5 }}
-                viewport={{ once: true }}
-              />
-            </m.h2>
+            </AnimatedHeadline>
             
             <div className="space-y-6 text-gray-300 leading-relaxed">
               <MotionFadeIn as="p" delay={0.2}>
@@ -144,13 +132,11 @@ export function About() {
               }}
               transition={{ type: 'spring', stiffness: 200, damping: 25 }}
             >
-              <m.div
+              <AnimatedIcon
+                icon={item.icon}
                 className="w-12 h-12 mx-auto mb-3 flex items-center justify-center rounded-full bg-white/10"
-                whileHover={{ rotate: 360 }}
-                transition={{ duration: 0.5 }}
-              >
-                <item.icon className="h-6 w-6 text-white" />
-              </m.div>
+                iconClassName="h-6 w-6 text-white"
+              />
               <h4 className="text-white font-semibold mb-1">{item.title}</h4>
               <p className="text-gray-400 text-sm">{item.desc}</p>
             </m.div>

--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -5,6 +5,7 @@ import { Textarea } from "../ui/textarea";
 import { Mail, MapPin, Linkedin } from "lucide-react";
 import { m } from "motion/react";
 import { MotionFadeIn } from "../graphs/MotionFadeIn";
+import { AnimatedHeadline } from "../graphs/AnimatedHeadline";
 import { MotionSlideIn } from "../graphs/MotionSlideIn";
 import { useData } from '../context/DataContext';
 
@@ -13,13 +14,9 @@ export function Contact() {
   return (
     <section className="py-20 px-4 bg-black/20">
       <div className="max-w-6xl mx-auto">
-        <MotionFadeIn
-          as="h2"
-          className="text-3xl md:text-4xl font-bold text-center mb-12 text-white"
-          duration={0.8}
-        >
+        <AnimatedHeadline className="text-3xl md:text-4xl font-bold text-center mb-12 text-white">
           Let's Build Something Together
-        </MotionFadeIn>
+        </AnimatedHeadline>
         
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
           <MotionSlideIn direction="left">

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../ui/badge";
 import { ExternalLink, Github, ArrowRight } from "lucide-react";
 import { ProjectDetail } from "./ProjectDetail";
 import { MotionFadeIn } from "../graphs/MotionFadeIn";
+import { AnimatedHeadline } from "../graphs/AnimatedHeadline";
 import { useData } from "../context/DataContext";
 
 
@@ -38,11 +39,9 @@ export function Projects({ showAll = false }: ProjectsProps) {
     <>
     <section className="py-20 px-4">
       <div className="max-w-6xl mx-auto">
-        <MotionFadeIn>
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-12 text-white">
-            {showAll ? "All Projects" : "Featured Projects"}
-          </h2>
-        </MotionFadeIn>
+        <AnimatedHeadline className="text-3xl md:text-4xl font-bold text-center mb-12 text-white">
+          {showAll ? "All Projects" : "Featured Projects"}
+        </AnimatedHeadline>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {displayProjects.map((project, index) => (

--- a/src/app/components/Qualification.tsx
+++ b/src/app/components/Qualification.tsx
@@ -1,15 +1,13 @@
 import { m } from 'motion/react';
 import { MotionFadeIn } from "../graphs/MotionFadeIn";
+import { AnimatedHeadline } from "../graphs/AnimatedHeadline";
 
 export function Qualification() {
   
   return (
     <section className="relative py-32 px-4 overflow-hidden">
       <div className="max-w-6xl mx-auto relative z-10">
-        <MotionFadeIn
-          as="h2"
-          className="text-4xl md:text-5xl font-bold text-center mb-4 text-white relative"
-        >
+        <AnimatedHeadline className="text-4xl md:text-5xl font-bold text-center mb-4 text-white relative">
           <m.div
             className="absolute -top-8 left-1/2 transform -translate-x-1/2 w-32 h-1"
             style={{
@@ -25,7 +23,7 @@ export function Qualification() {
             }}
           />
           Qualification
-        </MotionFadeIn>
+        </AnimatedHeadline>
 
         <MotionFadeIn
           as="div"

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -1,5 +1,7 @@
 import { m } from 'motion/react';
 import { MotionFadeIn } from "../graphs/MotionFadeIn";
+import { AnimatedHeadline } from "../graphs/AnimatedHeadline";
+import { AnimatedIcon } from "../graphs/AnimatedIcon";
 import { Badge } from "../ui/badge";
 import { useMousePosition } from '../hooks/useMousePosition';
 import { useScrollPosition } from '../hooks/useScrollPosition';
@@ -42,13 +44,11 @@ export function Skills() {
       
 
       <div className="max-w-6xl mx-auto relative z-10">
-        <MotionFadeIn
-          as="h2"
+        <AnimatedHeadline
           className="text-4xl md:text-5xl font-bold text-center mb-4 text-white relative"
           style={{ transform: `translateY(${scrollY * -0.03}px)` }}
         >
           Tech Stack
-
           {/* Animated circuit lines */}
           <m.div
             className="absolute -top-8 left-1/2 transform -translate-x-1/2 w-32 h-1"
@@ -64,7 +64,7 @@ export function Skills() {
               delay: 0.5,
             }}
           />
-        </MotionFadeIn>
+        </AnimatedHeadline>
 
         <MotionFadeIn
           as="p"
@@ -111,13 +111,13 @@ export function Skills() {
                     whileHover={{ x: 5 }}
                     transition={{ type: 'spring', stiffness: 400, damping: 25 }}
                   >
-                    <m.div
+                    <AnimatedIcon
+                      icon={Icon}
                       className="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center mr-3"
+                      iconClassName="h-5 w-5 text-white"
                       whileHover={{ rotate: 360, scale: 1.1 }}
                       transition={{ duration: 0.5 }}
-                    >
-                      <Icon className="h-5 w-5 text-white" />
-                    </m.div>
+                    />
                     <h3 className="text-lg font-semibold text-white">
                       {category.title}
                     </h3>

--- a/src/app/components/WorkHistory.tsx
+++ b/src/app/components/WorkHistory.tsx
@@ -8,6 +8,7 @@ import { MotionFadeIn } from '../graphs/MotionFadeIn';
 import { MotionSlideIn } from '../graphs/MotionSlideIn';
 import { useData } from '../context/DataContext';
 import { AnimatedWorkHistory } from '../graphs';
+import { AnimatedHeadline } from '../graphs/AnimatedHeadline';
 
 interface WorkExperience {
   id: string;
@@ -70,15 +71,9 @@ export function WorkHistory() {
           }}
           transition={{ type: 'spring', stiffness: 150, damping: 20 }}
         >
-          <m.h2 
-            className="mb-6"
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-            viewport={{ once: true }}
-          >
+          <AnimatedHeadline className="mb-6">
             Professional Journey
-          </m.h2>
+          </AnimatedHeadline>
           <m.p 
             className="text-lg max-w-2xl mx-auto"
             style={{ color: 'rgba(255, 255, 255, 0.8)' }}

--- a/src/app/graphs/AnimatedHeadline.tsx
+++ b/src/app/graphs/AnimatedHeadline.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { m } from "motion/react";
+import type { CSSProperties, ReactNode } from "react";
+import { MotionFadeIn } from "./MotionFadeIn";
+import { cn } from "../ui/utils";
+
+interface AnimatedHeadlineProps {
+  children: ReactNode;
+  className?: string;
+  accent?: boolean;
+  delay?: number;
+  once?: boolean;
+  style?: CSSProperties;
+}
+
+export function AnimatedHeadline({
+  children,
+  className,
+  accent = false,
+  delay,
+  once,
+  style,
+}: AnimatedHeadlineProps) {
+  return (
+    <MotionFadeIn
+      as="h2"
+      className={cn(
+        "text-4xl md:text-5xl font-bold mb-8 text-white relative",
+        className,
+      )}
+      delay={delay}
+      once={once}
+      style={style}
+    >
+      {children}
+      {accent && (
+        <m.div
+          className="absolute -bottom-2 left-0 h-1 bg-gradient-to-r from-white via-gray-400 to-transparent"
+          initial={{ width: 0 }}
+          whileInView={{ width: "60%" }}
+          transition={{ duration: 1, delay: 0.5 }}
+          viewport={{ once: true }}
+        />
+      )}
+    </MotionFadeIn>
+  );
+}
+

--- a/src/app/graphs/AnimatedIcon.tsx
+++ b/src/app/graphs/AnimatedIcon.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { m, type MotionProps } from "motion/react";
+import { cn } from "../ui/utils";
+
+interface AnimatedIconProps extends MotionProps {
+  icon: ComponentType<any>;
+  className?: string;
+  iconClassName?: string;
+}
+
+export function AnimatedIcon({
+  icon: Icon,
+  className,
+  iconClassName,
+  whileHover,
+  transition,
+  ...props
+}: AnimatedIconProps) {
+  return (
+    <m.div
+      className={cn("flex items-center justify-center", className)}
+      whileHover={whileHover ?? { rotate: 360 }}
+      transition={transition ?? { duration: 0.5 }}
+      {...props}
+    >
+      <Icon className={cn(iconClassName)} />
+    </m.div>
+  );
+}
+

--- a/src/app/graphs/index.ts
+++ b/src/app/graphs/index.ts
@@ -11,3 +11,5 @@ export { MotionSection } from './MotionSection';
 export { MotionSlideIn } from './MotionSlideIn';
 
 export { ParallaxBackground } from './ParallaxBackground';
+export { AnimatedHeadline } from './AnimatedHeadline';
+export { AnimatedIcon } from './AnimatedIcon';


### PR DESCRIPTION
## Summary
- introduce `AnimatedHeadline` for consistent section headers with optional accent
- add `AnimatedIcon` to handle rotating icon hover effects
- refactor sections to use these reusable components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d62586e908331ac32a50881ef244c