### PR TITLE
refactor: add reusable hover glow card

### DIFF
--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -3,6 +3,7 @@ import { MotionFadeIn } from "../graphs/MotionFadeIn";
 import { useMousePosition } from '../hooks/useMousePosition';
 import { useScrollPosition } from '../hooks/useScrollPosition';
 import { Code2, Globe, Award, Users } from 'lucide-react';
+import { HoverGlowCard } from './HoverGlowCard';
 
 const highlights = [
   { icon: Code2, title: "15+ Years Experience", desc: "Full-stack mastery" },
@@ -127,7 +128,7 @@ export function About() {
           viewport={{ once: true }}
         >
           {highlights.map((item, index) => (
-            <m.div
+            <HoverGlowCard
               key={index}
               className="text-center p-6 rounded-xl relative"
               style={{
@@ -135,8 +136,7 @@ export function About() {
                 backdropFilter: 'blur(10px)',
                 border: '1px solid rgba(255, 255, 255, 0.05)',
               }}
-              whileHover={{ 
-                scale: 1.05,
+              whileHover={{
                 background: 'rgba(255, 255, 255, 0.05)',
               }}
               animate={{
@@ -153,7 +153,7 @@ export function About() {
               </m.div>
               <h4 className="text-white font-semibold mb-1">{item.title}</h4>
               <p className="text-gray-400 text-sm">{item.desc}</p>
-            </m.div>
+            </HoverGlowCard>
           ))}
         </m.div>
 

--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -44,23 +44,27 @@ export function Contact() {
             </div>
             
             <div className="space-y-4">
-              {links.map(l => { const Component = l.component; return (
-                <m.div 
-                  className="flex items-center gap-3 text-gray-300"
-                  whileHover={{ x: 5 }}
-                  transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-                >
-                  <Component className="h-5 w-5" />
-                  <a
-                    href={l.link}
-                    target="_blank" 
-                    rel="noopener noreferrer"
-                    className="hover:text-white transition-colors"
+              {links.map((l, index) => {
+                const Component = l.component;
+                return (
+                  <m.div
+                    key={index}
+                    className="flex items-center gap-3 text-gray-300"
+                    whileHover={{ x: 5 }}
+                    transition={{ type: 'spring', stiffness: 400, damping: 25 }}
                   >
-                    {l.label}
-                  </a>
-                </m.div>
-              )})}
+                    <Component className="h-5 w-5" />
+                    <a
+                      href={l.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-white transition-colors"
+                    >
+                      {l.label}
+                    </a>
+                  </m.div>
+                );
+              })}
             </div>
 
             

--- a/src/app/components/HoverGlowCard.tsx
+++ b/src/app/components/HoverGlowCard.tsx
@@ -1,0 +1,29 @@
+import { m, HTMLMotionProps } from 'motion/react';
+
+interface HoverGlowCardProps extends HTMLMotionProps<'div'> {
+  children: React.ReactNode;
+}
+
+export function HoverGlowCard({
+  children,
+  className = '',
+  whileHover: customHover,
+  ...props
+}: HoverGlowCardProps) {
+  return (
+    <m.div
+      className={`cursor-pointer transition-all duration-300 ${className}`}
+      whileHover={{
+        scale: 1.02,
+        boxShadow: '0 0 40px rgba(131, 56, 236, 0.3)',
+        ...(customHover as object),
+      }}
+      {...props}
+    >
+      {children}
+    </m.div>
+  );
+}
+
+export default HoverGlowCard;
+

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -7,6 +7,7 @@ import { ExternalLink, Github, ArrowRight } from "lucide-react";
 import { ProjectDetail } from "./ProjectDetail";
 import { MotionFadeIn } from "../graphs/MotionFadeIn";
 import { useData } from "../context/DataContext";
+import { HoverGlowCard } from './HoverGlowCard';
 
 
 interface ProjectsProps {
@@ -47,61 +48,63 @@ export function Projects({ showAll = false }: ProjectsProps) {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {displayProjects.map((project, index) => (
             <MotionFadeIn key={index} delay={index * 0.1}>
-              <Card className="bg-white/5 border-white/10 text-white hover:bg-white/10 transition-colors">
-                <CardHeader>
-                  <div className="flex justify-between items-start">
-                    <CardTitle className="text-xl text-white">{project.title}</CardTitle>
-                  {project.featured && (
-                    <Badge className="bg-white text-black">Featured</Badge>
-                  )}
-                </div>
-                <CardDescription className="text-gray-300">
-                  {project.description}
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-wrap gap-2 mb-4">
-                  {project.technologies.slice(0, 4).map((tech, techIndex) => (
-                    <Badge 
-                      key={techIndex} 
-                      variant="outline" 
-                      className="border-white/20 text-gray-300"
-                    >
-                      {tech}
-                    </Badge>
-                  ))}
-                  {project.technologies.length > 4 && (
-                    <Badge 
-                      variant="outline" 
-                      className="border-white/20 text-gray-300"
-                    >
-                      +{project.technologies.length - 4}
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex gap-2">
-                  <Button
-                    onClick={() => handleProjectSelect(project.id)}
-                    className="bg-white text-black hover:bg-gray-200"
-                  >
-                    <ArrowRight className="mr-2 h-4 w-4" />
-                    View Details
-                  </Button>
-                  <Button variant="outline" size="sm" className="bg-transparent border-white/20 text-white hover:bg-white/10" asChild>
-                    <a href={project.github || '#'} target="_blank" rel="noopener noreferrer">
-                      <Github className="mr-2 h-4 w-4" />
-                      Code
-                    </a>
-                  </Button>
-                  <Button variant="outline" size="sm" className="bg-transparent border-white/20 text-white hover:bg-white/10" asChild>
-                    <a href={project.demo || '#'} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      Demo
-                    </a>
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
+              <HoverGlowCard>
+                <Card className="bg-white/5 border-white/10 text-white hover:bg-white/10 transition-colors">
+                  <CardHeader>
+                    <div className="flex justify-between items-start">
+                      <CardTitle className="text-xl text-white">{project.title}</CardTitle>
+                      {project.featured && (
+                        <Badge className="bg-white text-black">Featured</Badge>
+                      )}
+                    </div>
+                    <CardDescription className="text-gray-300">
+                      {project.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex flex-wrap gap-2 mb-4">
+                      {project.technologies.slice(0, 4).map((tech, techIndex) => (
+                        <Badge
+                          key={techIndex}
+                          variant="outline"
+                          className="border-white/20 text-gray-300"
+                        >
+                          {tech}
+                        </Badge>
+                      ))}
+                      {project.technologies.length > 4 && (
+                        <Badge
+                          variant="outline"
+                          className="border-white/20 text-gray-300"
+                        >
+                          +{project.technologies.length - 4}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        onClick={() => handleProjectSelect(project.id)}
+                        className="bg-white text-black hover:bg-gray-200"
+                      >
+                        <ArrowRight className="mr-2 h-4 w-4" />
+                        View Details
+                      </Button>
+                      <Button variant="outline" size="sm" className="bg-transparent border-white/20 text-white hover:bg-white/10" asChild>
+                        <a href={project.github || '#'} target="_blank" rel="noopener noreferrer">
+                          <Github className="mr-2 h-4 w-4" />
+                          Code
+                        </a>
+                      </Button>
+                      <Button variant="outline" size="sm" className="bg-transparent border-white/20 text-white hover:bg-white/10" asChild>
+                        <a href={project.demo || '#'} target="_blank" rel="noopener noreferrer">
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          Demo
+                        </a>
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </HoverGlowCard>
             </MotionFadeIn>
           ))}
         </div>

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -6,6 +6,7 @@ import { useMousePosition } from '../hooks/useMousePosition';
 import { useScrollPosition } from '../hooks/useScrollPosition';
 import { Code, Database, Cloud, Zap, Wrench, TestTube } from 'lucide-react';
 import { useData } from '../context/DataContext';
+import { HoverGlowCard } from './HoverGlowCard';
 
 export function Skills() {
   const scrollY = useScrollPosition();
@@ -61,7 +62,7 @@ export function Skills() {
           {skillCategories.map((category, index) => {
             const Icon = category.icon;
             return (
-              <m.div
+              <HoverGlowCard
                 key={index}
                 className="relative group"
                 style={{ transform: `translateY(${scrollY * (index % 2 === 0 ? -0.02 : 0.02)}px)` }}
@@ -73,8 +74,7 @@ export function Skills() {
                 initial={{ opacity: 0, y: 30 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
-                whileHover={{ 
-                  scale: 1.02,
+                whileHover={{
                   rotateY: index % 2 === 0 ? 2 : -2,
                 }}
               >
@@ -163,7 +163,7 @@ export function Skills() {
                     />
                   ))}
                 </div>
-              </m.div>
+              </HoverGlowCard>
             );
           })}
         </div>

--- a/src/app/components/WorkHistory.tsx
+++ b/src/app/components/WorkHistory.tsx
@@ -8,6 +8,7 @@ import { MotionFadeIn } from '../graphs/MotionFadeIn';
 import { MotionSlideIn } from '../graphs/MotionSlideIn';
 import { useData } from '../context/DataContext';
 import { AnimatedWorkHistory } from '../graphs';
+import { HoverGlowCard } from './HoverGlowCard';
 
 interface WorkExperience {
   id: string;
@@ -99,12 +100,8 @@ export function WorkHistory() {
               animateStyle={{ x: mouseXPercent * (index % 2 === 0 ? 2 : -2) }}
               transition={{ type: 'spring', stiffness: 200, damping: 25 }}
             >
-              <m.div
-                className="cyber-glass-purple cyber-glass-purple-box cyber-glass-box rounded-xl p-8 cursor-pointer transition-all duration-300"
-                whileHover={{
-                  scale: 1.02,
-                  boxShadow: '0 0 40px rgba(131, 56, 236, 0.3)',
-                }}
+              <HoverGlowCard
+                className="cyber-glass-purple cyber-glass-purple-box cyber-glass-box rounded-xl p-8 cursor-pointer"
                 onClick={() => toggleExpanded(exp.id)}
               >
                 {/* Header */}
@@ -259,7 +256,7 @@ export function WorkHistory() {
                     </div>
                   </div>
                 </m.div>
-              </m.div>
+              </HoverGlowCard>
             </MotionFadeIn>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add reusable `HoverGlowCard` component encapsulating hover scale + glow effect
- refactor About, Projects, Skills, and WorkHistory to use `HoverGlowCard`
- fix missing `key` prop in Contact links

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d768e1d18833180dbc9a073fe89c1